### PR TITLE
fix(skyfrost): add reference to SkyFrost.Base.Models

### DIFF
--- a/BetterInventoryBrowser.csproj
+++ b/BetterInventoryBrowser.csproj
@@ -41,6 +41,9 @@
     <Reference Include="SkyFrost.Base">
       <HintPath>$(AppPath)$(AppName)_Data\Managed\SkyFrost.Base.dll</HintPath>
     </Reference>
+    <Reference Include="SkyFrost.Base.Models">
+      <HintPath>$(AppPath)$(AppName)_Data\Managed\SkyFrost.Base.Models.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>$(AppPath)$(AppName)_Data\Managed\Newtonsoft.Json.dll</HintPath>
     </Reference>


### PR DESCRIPTION
As of 2024.6.10.1405, the models from SkyFrost.Base have been refactored out and moved into a separate DLL called SkyFrost.Base.Models.dll. This PR adds the reference to the new DLL.